### PR TITLE
Add meeting minutes for April 22, 2025

### DIFF
--- a/2025-04-22-meeting.md
+++ b/2025-04-22-meeting.md
@@ -1,0 +1,127 @@
+# Data Provenance Standards Technical Committee  
+## Meeting Minutes – April 22, 2025
+
+**Chairs:** Bryan Bortnick, Lisa Bobbitt, Fotis Psallidas  
+
+**Presentation used during the meeting:**  
+[View Google Slides](https://docs.google.com/presentation/d/1wOMNZ0w20vILf2OE_TmhTwZ7eOw7YPvcU25_CheSIZo/edit?usp=sharing)
+
+---
+
+### Attendees  
+(*Denotes voting members)
+
+- Lisa Bobbitt*  
+- Bryan Bortnick*  
+- Mic Bowman  
+- Carlyn Connolly*  
+- Kelly Cullinane  
+- Michele Drgon  
+- Kate Gallo*  
+- Stefan Hagen*  
+- Andy Hannah*  
+- Jassim Happa  
+- David Kemp*  
+- Peter Koen  
+- Bryan Kyle*  
+- Greg Ott*  
+- Kristina Podnar*  
+- Fotis Psallidas*  
+- Wyatt Schroth*  
+- Kelsey Schulte*  
+- Duncan Sparrell*  
+- Laurie Tyzenhaus*  
+- Roman Zhukov*  
+
+**DPS TC Voting Rights Tracking sheet:**  
+[View Google Sheet](https://docs.google.com/spreadsheets/d/1HQXa69nD3AI5DoR6iOpUgrICzEj9erCMoaKhdgUbKzc/edit?usp=sharing)
+
+---
+
+### Agenda
+
+- Welcome & Introductions  
+- Roll Call and Quorum Confirmation  
+- Approval of April 8 Meeting Minutes  
+- Status of Contributions from Data & Trust Alliance  
+- Discussion of Proposed Work Products  
+- Repository and GitHub Organization  
+- Committee Specification Structure and Tooling
+
+---
+
+### Minutes
+
+**Roll Call**  
+Roll call took place, and a quorum was confirmed with 18 out of 20 voting members present. Per the OASIS TC process, this satisfies the requirement for conducting official business.
+
+**Recording Approval**  
+No objections. Recording initiated for note-taking purposes.
+
+**Meeting Minutes Approval**  
+April 8, 2025 meeting minutes adopted without objection.
+
+**Contributions Update**  
+Kristina confirmed Data & Trust Alliance contributions include:
+- Executive Overview  
+- Data Provenance Standards Documents  
+- Metadata Generator Tool (Azure-hosted)  
+- Use Cases  
+- GitHub zip archive of the full contribution
+
+Duncan clarified that uploading via the document repository with email notification qualifies as a formal contribution under OASIS IP rules. These materials became usable in TC discussions but have not yet been formally accepted as TC work products.
+
+---
+
+### Motions Passed
+
+- **Establish an open repository for Metadata Generator:**  
+  Motion passed to create a separate OASIS Open repository for hosting the Metadata Generator tool as open source.
+
+- **Establish GitHub pages for a public-facing executive brief:**  
+  A separate repo will be created for outward communications and adoption materials based on the executive briefing.
+
+- **Provisional acceptance of base documents:**  
+  A provisional agreement was reached to use the Data Provenance Specification and Use Cases documents as baseline input for committee specifications (to be formalized later).
+
+- **Standing rule on pull request process:**  
+  Pull requests to draft specs require a second and a one-week public review for consensus before merging.  
+  Repository maintainers may maintain the contributions directory without full TC approval.
+
+---
+
+### Key Discussion Points
+
+- **OASIS Work Product Process:**  
+  Duncan and Kelly clarified the process of formalizing committee specifications, including the need for selecting editors and file formats.  
+  Kelly will provide template documents for TC members to review prior to finalizing work product structures.
+
+- **Spec Structuring Recommendations:**  
+  Treating the specification and use cases as separate committee specifications was recommended.  
+  Discussion of using an information model as a central artifact from which different data encodings (JSON, XML, etc.) are derived will be taken up outside of this meeting.
+
+- **Work Product Definitions (Pending Formal Motion):**
+  - Data Provenance Specification (Standards Track)  
+  - Use Cases (Standards Track or Committee Note)  
+  - Metadata Generator (Open-Source Tool)  
+  - Public-Facing Executive Brief (Awareness/Adoption, not a standard)
+
+---
+
+### Action Items
+
+- **Kelly:** Send out OASIS spec templates to the mailing list.  
+- **Kristina:** Coordinate uploading contributions and sharing access.  
+- **TC Members:** Review materials and prepare feedback before the next meeting.  
+- **Kelly:** Send calendar invites for recurring meetings.  
+- **Kristina:** Initiate call for spec editors via email.  
+- **Absent TC Members:** Must advise if the proposed biweekly meeting cadence at 10am EDT does not work for their schedules; otherwise, cadence will be adopted.
+
+---
+
+### Upcoming Meetings
+
+- **Date:** May 6, 2025  
+- **Time:** 10:00 AM EDT  
+- **Cadence:** Biweekly  
+- **Note:** Members are to notify the TC if the time zone poses challenges.


### PR DESCRIPTION
This pull request adds the meeting minutes from the April 22, 2025 Data Provenance Standards TC meeting.

Minutes include:
- Roll call and quorum confirmation
- Status of contributions from Data & Trust Alliance
- Passed motions and decisions
- Work product definitions
- Action items and next steps

Per OASIS Open process, this is submitted for **lazy consensus**.

Please provide comments or objections by **[April 29, 2025]**.

If no objections are raised by that date, these minutes will be considered approved and the PR will be merged.
