### PR TITLE
Meeting 2025-05-20 minutes

### DIFF
--- a/MeetingMinutes/2025-05-20-meeting.md
+++ b/MeetingMinutes/2025-05-20-meeting.md
@@ -118,17 +118,17 @@ Passcode: `a0P3=w*%`
 
 ## XI. Action Items
 
-| Who | Action |
-|-----|--------|
-| Kristina | Share role-based use cases with Lisa |
-| All Members | Review PR #17 template and begin submitting use cases |
-| All Members | Use updated contributor-level folder structure |
-| Bryan & Andy | Convene executive briefing drafting group |
-| Kelsey | Check internally for effective executive brief examples |
-| Lisa | Reach out to CoSAI for example executive briefs guidance (input) |
-| Dave & Stefan | Continue modeling and prep for demo or walkthrough |
-| All Members | Review GitHub Issue #7 and contribute feedback |
-| Kristina/Kelly | Resolve calendar invite issues ahead of June 3 meeting |
+| Who            | Action                                                           |
+|:---------------|:-----------------------------------------------------------------|
+| All Members    | Review GitHub Issue #7 and contribute feedback                   |
+| All Members    | Review PR #17 template and begin submitting use cases            |
+| All Members    | Use updated contributor-level folder structure                   |
+| Bryan & Andy   | Convene executive briefing drafting group                        |
+| Dave & Stefan  | Continue modeling and prep for demo or walkthrough               |
+| Kelsey         | Check internally for effective executive brief examples          |
+| Kristina       | Share role-based use cases with Lisa                             |
+| Kristina/Kelly | Resolve calendar invite issues ahead of June 3 meeting           |
+| Lisa           | Reach out to CoSAI for example executive briefs guidance (input) |
 
 ## XII. Upcoming Meeting
 

--- a/MeetingMinutes/2025-05-20-meeting.md
+++ b/MeetingMinutes/2025-05-20-meeting.md
@@ -1,0 +1,138 @@
+
+# Data Provenance Standards Technical Committee Meeting
+
+**Meeting Date:** May 20, 2025  
+**Time:** 10:00 AM EDT (14:00 UTC / 16:00 CET / 7:00 AM PDT)
+
+**Chairs:**  
+- Bryan Bortnick (IBM)  
+- Lisa Bobbitt (Cisco)  
+- Fotis Psallidas (Microsoft)
+
+**Secretary:**  
+- Kristina Podnar (Data & Trust Alliance)
+
+**Presentation Slides:**  
+[View Slide Deck](https://drive.google.com/file/d/18VMo97cQxQIKY-09TsOuhtwcHFyCdPnx/view?usp=sharing)
+
+**Meeting Recording:**  
+[Zoom Recording](https://thecge-net.zoom.us/rec/share/WGzscNRbStpsUNSDtkdElD5N18GdE6UiFRzRrRULhTbBTv8-b0xVz1wBCfufQGRW.PT0Hy327lVBjaTCS)  
+Passcode: `a0P3=w*%`
+
+## I. Call to Order and Welcome
+
+- Fotis welcomed participants and reviewed the agenda
+- Kristina confirmed recording was in progress (non-public)
+- Meeting was called to order. Quorum was confirmed with 16 members present, 13 with voting rights, satisfying the requirement of 10 voting members
+
+## II. Agenda
+
+- Welcome  
+- Motions and updates since last meeting  
+- Use case development  
+- Executive brief  
+- Promotion and adoption of our work  
+- Metadata elements  
+- Modeling and JADN specification  
+- Wrap-up and next steps
+
+## III. Participants
+
+| Given Name | Family Name | Affiliation | Role | Present |
+|------------|-------------|-------------|------|---------|
+| Lisa | Bobbitt | Cisco | Voting Member | Present |
+| Bryan | Bortnick | IBM | Voting Member | Present |
+| Fotis | Psallidas | Microsoft | Voting Member, Co-Chair | Present |
+| Kristina | Podnar | D&TA | Voting Member, Secretary | Present |
+| Carlyn | Connolly | D&TA | Voting Member | Present |
+| Kate | Gallo | Blue Street Data | Voting Member | Present |
+| Stefan | Hagen | Individual | Voting Member | Present |
+| Andy | Hannah | Blue Street Data | Voting Member | Present |
+| David | Kemp | National Security Agency | Voting Member | Present |
+| Bryan | Kyle | IBM | Voting Member | Present |
+| Wyatt | Schroth | Blue Street Data | Voting Member | Present |
+| Kelsey | Schulte | Intel | Voting Member | Present |
+| Laurie | Tyzenhaus | Carnegie Mellon | Voting Member | Present |
+| Mic | Bowman | Intel | Non-Voting Member | Present |
+| Michele | Drgon | DataProbity | Non-Voting Member | Present |
+| Jenaye | Minter | Unknown | Non-Voting Member | Present |
+| Kelly | Cullinane | OASIS | Staff | Present |
+
+### Voting Rights Status
+
+- **Members at risk of losing voting rights if absent at next meeting:**
+  - Saira Jesani  
+  - Greg Ott  
+  - Duncan Sparrell  
+  - Jautau White  
+  - Roman Zhukov
+
+## IV. Work Approved Between Meetings
+
+- Meeting minutes from May 6, 2025 were formally adopted via lazy consensus
+- PR #17 (Use Case Template) was circulated ahead of the meeting for review
+- Proposal to restructure the contributions directory was shared via email for discussion (PR #18)
+
+## V. Motions Passed
+
+- **Approval of PR #17**  
+  The committee formally adopted PR #17, establishing the initial template for the Use Case Committee Note
+
+- **Contributor folder structure**  
+  The committee approved the addition of contributor-level folders within the `contributions/` directory to maintain clarity of source and attribution, and changes will result in PR #18.
+
+## VI. Contributions Discussion
+
+- Kristina introduced David Kemp’s proposal to track individual contributions with subfolders
+- Stefan supported the structure with caveats for small derivative changes
+- Lisa and Kelly emphasized the importance of attribution and traceability
+- Adopted structure: `contributions/<source>/<item>`
+
+## VII. Licensing Discussion
+
+- Stefan defaulted to MIT for his contributions
+- Bryan noted Apache may offer stronger attribution for future official work
+- The group agreed to continue using MIT (or one's prefered license) for contributions and to revisit license structure as needed
+
+## VIII. Use Case Development
+
+- Lisa invited members to submit use cases using the approved PR #17 template
+- Goal is to complete a first round of use cases by the end of June
+- Kristina will share role-based use cases from D&TA
+- Wyatt emphasized the importance of use cases tailored to specific user roles
+
+## IX. Executive Briefing Workstream
+
+- Bryan and Andy will co-lead drafting of the executive brief
+- The team aims to complete the first version by end of June
+- Kelsey (Intel) will look internally for useful examples
+- Lisa (Cisco) is reaching out to CoSAI for executive brief samples and guidance
+- Additional volunteers are encouraged to join this outreach-focused workstream
+
+## X. Metadata Elements & Information Modeling
+
+- Dave presented a conceptual information model to guide metadata schema and tool development
+- Stefan cautioned against premature standardization and emphasized flexibility and clarity in modeling
+- Kristina supported an iterative approach grounded in real-world adoption
+- Members will review GitHub Issue #7 and share feedback ahead of next meeting
+
+## XI. Action Items
+
+| Who | Action |
+|-----|--------|
+| Kristina | Share role-based use cases with Lisa |
+| All Members | Review PR #17 template and begin submitting use cases |
+| All Members | Use updated contributor-level folder structure |
+| Bryan & Andy | Convene executive briefing drafting group |
+| Kelsey | Check internally for effective executive brief examples |
+| Lisa | Reach out to CoSAI for example executive briefs guidance (input) |
+| Dave & Stefan | Continue modeling and prep for demo or walkthrough |
+| All Members | Review GitHub Issue #7 and contribute feedback |
+| Kristina/Kelly | Resolve calendar invite issues ahead of June 3 meeting |
+
+## XII. Upcoming Meeting
+
+**Date:** June 3, 2025  
+**Time:** 10:00 AM EDT  
+**Cadence:** Biweekly  
+**Note:** Contact Kristina or Kelly if you did not receive a calendar invite

--- a/MeetingMinutes/2025-05-20-meeting.md
+++ b/MeetingMinutes/2025-05-20-meeting.md
@@ -38,25 +38,25 @@ Passcode: `a0P3=w*%`
 
 ## III. Participants
 
-| Given Name | Family Name | Affiliation | Role | Present |
-|------------|-------------|-------------|------|---------|
-| Lisa | Bobbitt | Cisco | Voting Member | Present |
-| Bryan | Bortnick | IBM | Voting Member | Present |
-| Fotis | Psallidas | Microsoft | Voting Member, Co-Chair | Present |
-| Kristina | Podnar | D&TA | Voting Member, Secretary | Present |
-| Carlyn | Connolly | D&TA | Voting Member | Present |
-| Kate | Gallo | Blue Street Data | Voting Member | Present |
-| Stefan | Hagen | Individual | Voting Member | Present |
-| Andy | Hannah | Blue Street Data | Voting Member | Present |
-| David | Kemp | National Security Agency | Voting Member | Present |
-| Bryan | Kyle | IBM | Voting Member | Present |
-| Wyatt | Schroth | Blue Street Data | Voting Member | Present |
-| Kelsey | Schulte | Intel | Voting Member | Present |
-| Laurie | Tyzenhaus | Carnegie Mellon | Voting Member | Present |
-| Mic | Bowman | Intel | Non-Voting Member | Present |
-| Michele | Drgon | DataProbity | Non-Voting Member | Present |
-| Jenaye | Minter | Unknown | Non-Voting Member | Present |
-| Kelly | Cullinane | OASIS | Staff | Present |
+| Given Name | Family Name | Affiliation              | Role                     | Present |
+|:-----------|:------------|:-------------------------|:-------------------------|:--------|
+| Andy       | Hannah      | Blue Street Data         | Voting Member            | Present |
+| Bryan      | Bortnick    | IBM                      | Voting Member            | Present |
+| Bryan      | Kyle        | IBM                      | Voting Member            | Present |
+| Carlyn     | Connolly    | D&TA                     | Voting Member            | Present |
+| David      | Kemp        | National Security Agency | Voting Member            | Present |
+| Fotis      | Psallidas   | Microsoft                | Voting Member, Co-Chair  | Present |
+| Jenaye     | Minter      | Unknown                  | Non-Voting Member        | Present |
+| Kate       | Gallo       | Blue Street Data         | Voting Member            | Present |
+| Kelly      | Cullinane   | OASIS                    | Staff                    | Present |
+| Kelsey     | Schulte     | Intel                    | Voting Member            | Present |
+| Kristina   | Podnar      | D&TA                     | Voting Member, Secretary | Present |
+| Laurie     | Tyzenhaus   | Carnegie Mellon          | Voting Member            | Present |
+| Lisa       | Bobbitt     | Cisco                    | Voting Member            | Present |
+| Mic        | Bowman      | Intel                    | Non-Voting Member        | Present |
+| Michele    | Drgon       | DataProbity              | Non-Voting Member        | Present |
+| Stefan     | Hagen       | Individual               | Voting Member            | Present |
+| Wyatt      | Schroth     | Blue Street Data         | Voting Member            | Present |
 
 ### Voting Rights Status
 


### PR DESCRIPTION
Adds the official meeting minutes from the May 20, 2025 Data Provenance Standards TC meeting.

Minutes from May 20, 2025 meeting DPS TC include quorum confirmation, motions passed (PR #17 and contributor folder proposal), and key discussions around use case development, executive brief, metadata modeling, and upcoming action items.