### PR TITLE
2025-06-17 Data Provenance Standards TC Meeting Notes

### DIFF
--- a/MeetingMinutes/2025-06-17-meeting.md
+++ b/MeetingMinutes/2025-06-17-meeting.md
@@ -1,0 +1,124 @@
+# Data Provenance Standards Technical Committee Meeting
+
+**Meeting Date:** June 17, 2025  
+**Time:** 7:00 AM PDT / 10:00 AM EDT / 14:00 UTC / 16:00 CET
+
+**Chairs:**  
+- Lisa Bobbitt (Cisco)  
+- Fotis Psallidas (Microsoft)  
+- Bryan Bortnick (IBM) *(Absent)*
+
+**Secretary:**  
+- Kristina Podnar (Data & Trust Alliance)
+
+**Presentation Slides:**  
+[Meeting Slide Deck](https://drive.google.com/file/d/1B64dUn8rP9Gc4_GEbVxBsQCh6BsdhfJ2/view?usp=sharing)
+
+**Metadata Walkthrough Presentation:**  
+[Metadata Standards Walkthrough (Kristina Podnar)](https://drive.google.com/file/d/1B64dUn8rP9Gc4_GEbVxBsQCh6BsdhfJ2/view?usp=sharing)
+
+**Meeting Recording:**  
+[Zoom Recording](https://thecge-net.zoom.us/rec/share/VDAtkYj9Q6zzON4RP3znkeQO2lPFWeduoL_eQrPkjfYQVpEY7c29WBe9YkNQFoJA.BBLscplhP6AEfIWu)  
+Passcode: `ritX*2N0`
+
+---
+
+## I. Call to Order and Welcome
+
+- Lisa welcomed participants and confirmed quorum.
+- Kristina confirmed the meeting was being recorded (non-public).
+- The meeting was officially called to order with quorum met.
+
+---
+
+## II. Agenda Overview
+
+- Review and approval of PRs shared via email  
+- Background on metadata standards  
+- Walkthrough of metadata elements  
+- Group discussion  
+- Next steps and action items
+
+---
+
+## III. Participants
+
+| Given Name | Family Name | Affiliation              | Role                     | Present |
+|------------|-------------|---------------------------|--------------------------|---------|
+| Lisa       | Bobbitt     | Cisco                    | Voting Member, Co-Chair  | Present |
+| Fotis      | Psallidas   | Microsoft                | Voting Member, Co-Chair  | Present |
+| Bryan      | Bortnick    | IBM                      | Voting Member, Co-Chair  | Absent  |
+| Mic        | Bowman      | Intel                    | Non-Voting Member        | Present |
+| Michele    | Drgon       | DataProbity              | Non-Voting Member        | Present |
+| Carlyn     | Connolly    | D&TA                     | Voting Member            | Present |
+| Kate       | Gallo       | Blue Street Data         | Voting Member            | Present |
+| Stefan     | Hagen       | Individual               | Voting Member            | Present |
+| Andy       | Hannah      | Blue Street Data         | Voting Member            | Present |
+| Saira      | Jesani      | Data & Trust Alliance    | Voting Member            | Present |
+| David      | Kemp        | National Security Agency | Voting Member            | Present |
+| Bryan      | Kyle        | IBM                      | Voting Member            | Present |
+| Greg       | Ott         | National Security Agency | Voting Member            | Present |
+| Kristina   | Podnar      | D&TA                     | Voting Member, Secretary | Present |
+| Kelsey     | Schulte     | Intel                    | Voting Member            | Present |
+| Jautau     | White       | Microsoft                | Voting Member            | Present |
+| Roman      | Zhukov      | Red Hat                  | Voting Member            | Present |
+| Wyatt      | Schroth     | Blue Street Data         | Voting Member            | Present |
+
+### Voting Rights Status
+
+- **At risk of losing voting rights if absent at next meeting:**
+  - Bryan Bortnick
+
+---
+
+## IV. Work Approved Between Meetings
+
+The following PRs were approved via email with no objections:
+
+- **PR #39:** Seed as a service for DTA JS/TS contribution maintenance  
+- **PR #38:** Update `javascript_typescript` (#35, #37: creating and deleting contribution by @kpodnar)  
+- **PR #34:** Meeting minutes for June 3, 2025 TC meeting  
+- **PR #30:** Add FAQ numbers to README
+
+---
+
+## V. Data Provenance Standards Context and Metadata Walkthrough
+
+Kristina provided a full overview of the D&TA’s metadata standards development:
+
+- Origin in over 25 use cases from D&TA members and cross-industry consultation
+- Refinement from 58 metadata fields to a 22-element core set
+- Design for machine-readability and pragmatic adoption
+- Fields include standard versioning, data issuer/source, licensing, confidentiality, provenance lineage, and usage permissions
+
+She emphasized flexibility, backward compatibility, and iterative enhancement through tooling.
+
+---
+
+## VI. Open Discussion Highlights
+
+- UUIDs and dataset versions: Need for clarity on linkage and evolution (Mic, Dave)
+- Field definitions and naming: Suggestions to improve semantics (Lisa, Greg, Stefan)
+- Use metadata: Recommendation to differentiate between intended use and restricted use
+- Licensing and consent metadata: Clear display of license location and consent documents improves trust assessment
+- Dynamic metadata management: Concerns around maintaining current data were acknowledged; flagged for tooling solution
+
+---
+
+## VII. Action Items
+
+| Who         | Action                                                                 |
+|-------------|------------------------------------------------------------------------|
+| Kristina    | Share presentation deck, [metadata Excel schema](https://github.com/oasis-tcs/dps/blob/main/contributions/dta/schema/MVP%20Master%20Standards%20with%20Definitions%2004-24-24%20v10eh.xlsx), and [metadata generator tool](https://data-and-trust-alliance-data-provenance-standards.northeurope.cloudapp.azure.com) |
+| All Members | Review the 22-element metadata and suggest improvements                |
+| All Members | Discuss approach for restricted use metadata field                     |
+| All Members | Consider implementation needs for dynamic and persistent metadata      |
+
+---
+
+## VIII. Upcoming Meeting
+
+**Date:** July 1, 2025  
+**Time:** 10:00 AM EDT  
+**Cadence:** Biweekly  
+**Note:** Contact Kristina or Kelly if calendar invites are missing or incorrect


### PR DESCRIPTION
Meeting notes from the June 17, 2025 session of the OASIS DPS TC. Includes participant list, agenda, approved pull requests, metadata standards walkthrough, discussion highlights, and assigned action items. Useful for tracking progress on the metadata schema and aligning on next steps for implementation.