### PR TITLE
July 1, 2025 DPS TC Meeting Minutes

### DIFF
--- a/MeetingMinutes/2025-07-01-meeting.md
+++ b/MeetingMinutes/2025-07-01-meeting.md
@@ -23,27 +23,26 @@
 
 ## Attendance
 
-| Given Name | Family Name | Affiliation               | Roles                    | Present |
-|:-----------|:------------|:--------------------------|:-------------------------|:--------|
-| Andy       | Hannah      | Blue Street Data | Voting Member | Yes |
-| Bryan      | Bortnick    | IBM | Voting Member, Co-Chair | Yes |
-| Bryan      | Kyle        | IBM | Voting Member | No |
-| Carlyn     | Connolly    | Data & Trust Alliance | Voting Member | Yes |
-| David      | Kemp        | National Security Agency | Voting Member | Yes |
-| Fotis      | Psallidas   | Microsoft | Voting Member, Co-Chair | No |
-| Greg       | Ott         | National Security Agency | Voting Member | No |
-| Jautau     | White       | Microsoft | Voting Member | Yes |
-| Kate       | Gallo       | Blue Street Data | Voting Member | Yes |
-| Kelsey     | Schulte     | Intel | Voting Member | Yes |
-| Kristina   | Podnar      | Data & Trust Alliance | Voting Member, Secretary | Yes |
-| Lisa       | Bobbitt     | Cisco | Voting Member, Co-Chair | Yes |
-| Mic        | Bowman      | Intel | Non-Voting Member | Yes |
-| Michele    | Drgon       | DataProbity | Non-Voting Member | No |
-| Roman      | Zhukov      | Red Hat | Voting Member | Yes |
-| Saira      | Jesani      | Data & Trust Alliance | Voting Member | No |
-| Stefan     | Hagen       | Individual | Voting Member | Yes |
-| Wyatt      | Schroth     | Blue Street Data | Voting Member | No |
-
+| Given Name | Family Name | Affiliation              | Roles                    | Present |
+|:-----------|:------------|:-------------------------|:-------------------------|:--------|
+| Andy       | Hannah      | Blue Street Data         | Voting Member            | Yes     |
+| Bryan      | Bortnick    | IBM                      | Voting Member, Co-Chair  | Yes     |
+| Bryan      | Kyle        | IBM                      | Voting Member            | No      |
+| Carlyn     | Connolly    | Data & Trust Alliance    | Voting Member            | Yes     |
+| David      | Kemp        | National Security Agency | Voting Member            | Yes     |
+| Fotis      | Psallidas   | Microsoft                | Voting Member, Co-Chair  | No      |
+| Greg       | Ott         | National Security Agency | Voting Member            | No      |
+| Jautau     | White       | Microsoft                | Voting Member            | Yes     |
+| Kate       | Gallo       | Blue Street Data         | Voting Member            | Yes     |
+| Kelsey     | Schulte     | Intel                    | Voting Member            | Yes     |
+| Kristina   | Podnar      | Data & Trust Alliance    | Voting Member, Secretary | Yes     |
+| Lisa       | Bobbitt     | Cisco                    | Voting Member, Co-Chair  | Yes     |
+| Mic        | Bowman      | Intel                    | Non-Voting Member        | Yes     |
+| Michele    | Drgon       | DataProbity              | Non-Voting Member        | No      |
+| Roman      | Zhukov      | Red Hat                  | Voting Member            | Yes     |
+| Saira      | Jesani      | Data & Trust Alliance    | Voting Member            | No      |
+| Stefan     | Hagen       | Individual               | Voting Member            | Yes     |
+| Wyatt      | Schroth     | Blue Street Data         | Voting Member            | No      |
 
 ## Agenda
 

--- a/MeetingMinutes/2025-07-01-meeting.md
+++ b/MeetingMinutes/2025-07-01-meeting.md
@@ -1,0 +1,79 @@
+
+# OASIS TC Meeting – July 1, 2025
+
+**Date:** July 1, 2025  
+**Time:** 7:00 AM PDT / 10:00 AM EDT / 14:00 UTC / 16:00 CET  
+
+**Chairs:**  
+- Bryan Bortnick (IBM)  
+- Lisa Bobbitt (Cisco)  
+- Fotis Psallidas (Microsoft)  
+
+**Secretary:**  
+- Kristina Podnar (Data &amp; Trust Alliance)  
+
+**Meeting Recording:**  
+[Watch recording on Zoom](https://thecge-net.zoom.us/rec/share/J0sgfmQxWbCJKLF1BT6s4bLK99APVbyjPvP_k1j2jQj6Qq1DImaUIn2Yg5Mo2Sdd.q4ovJmUV8IoXBsY1)  
+**Passcode:** `s$8o=njL`  
+
+**Presentation:**  
+[View presentation on Google Drive](https://drive.google.com/file/d/1M58KHKH6zmPkfVwu55FDB2-BQxnNniIH/view?usp=sharing)
+
+---
+
+## Attendance
+
+| Given Name | Family Name | Affiliation               | Roles                    | Present |
+|:-----------|:------------|:--------------------------|:-------------------------|:--------|
+| Andy       | Hannah      | Blue Street Data | Voting Member | Yes |
+| Bryan      | Bortnick    | IBM | Voting Member, Co-Chair | Yes |
+| Bryan      | Kyle        | IBM | Voting Member | No |
+| Carlyn     | Connolly    | Data & Trust Alliance | Voting Member | Yes |
+| David      | Kemp        | National Security Agency | Voting Member | Yes |
+| Fotis      | Psallidas   | Microsoft | Voting Member, Co-Chair | No |
+| Greg       | Ott         | National Security Agency | Voting Member | No |
+| Jautau     | White       | Microsoft | Voting Member | Yes |
+| Kate       | Gallo       | Blue Street Data | Voting Member | Yes |
+| Kelsey     | Schulte     | Intel | Voting Member | Yes |
+| Kristina   | Podnar      | Data & Trust Alliance | Voting Member, Secretary | Yes |
+| Lisa       | Bobbitt     | Cisco | Voting Member, Co-Chair | Yes |
+| Mic        | Bowman      | Intel | Non-Voting Member | Yes |
+| Michele    | Drgon       | DataProbity | Non-Voting Member | No |
+| Roman      | Zhukov      | Red Hat | Voting Member | Yes |
+| Saira      | Jesani      | Data & Trust Alliance | Voting Member | No |
+| Stefan     | Hagen       | Individual | Voting Member | Yes |
+| Wyatt      | Schroth     | Blue Street Data | Voting Member | No |
+
+
+## Agenda
+
+1. Approve prior meeting minutes and PRs  
+2. Workstream updates  
+3. Discussion: Timeline and priorities for releasing v1  
+
+---
+
+## Discussion Summary
+
+**Meeting kickoff**  
+Lisa opened the meeting by emphasizing the need for the TC to finalize and release a foundational version of the standard. She encouraged attendees to discuss whether to include additional fields (like "role" of data source) now or defer to a v2.
+
+**Timeline for publication**  
+There was broad agreement to prioritize publishing a v1 standard this summer (August 2025 target), with a clear path to incorporate enhancements in future versions. Bryan highlighted the urgency given regulatory developments (e.g., EU AI Act, U.S. discussions), and how a published draft would serve as a helpful reference for industry. Stefan urged the TC to consider the work to be done and the realistic ability to achieve success, rather than rush the process.
+
+**Use case and specification pathway**  
+Kristina summarized the two-part submission process: (1) move GitHub content into the OASIS specification template and submit for approval, and (2) compile use cases into a committee note. Kelly confirmed this is the correct procedure and reminded the group that the public review requires a minimum of 30 days.
+
+**Use case incorporation**  
+Stefan submitted additional use case ideas. Lisa recommended focusing v1 on the use cases already developed and appending new contributions into a v2 roadmap.
+
+**Consensus**  
+There was no objection to proceeding with v1 publication preparation. This may be a multi-step process by which we first publish the Executive Business Case for DPS and the Use Cases, followed at a later date by the standards specification. Lisa encouraged the group to be "agile" and get a version out the door to collect feedback and validate direction. She noted Cisco’s internal alignment efforts hinged on visible TC momentum. 
+
+---
+
+## Actions and Next Steps
+  
+- **Use case document**: Lisa to consolidate and incorporate Stefan’s additions. Kristina to support, and others provide input upon conclusion. Draft due: within one week  
+- **Target for v1 submission**: August/September 2025 with a staged rollout (Executive Brief, Use Cases, Standards Specifications
+- **Metadata Walkthrough**: Stefan to prepare a metadata walk through for the next meeting. All TC members are to consider the proposed approach, help fill in gaps, and to recommend what ought to be included in the initial specification (version 1.0.0) versus what should be addressed in a parallel effort with a longer timeline.


### PR DESCRIPTION
This file contains the official meeting minutes for the July 1, 2025 session of the OASIS DPS TC. It includes attendance (with voting status), key discussion points, consensus decisions, and action items. The minutes also document timeline alignment for v1 specification release, use case integration, and responsibilities for the upcoming July 15 meeting.