### PR TITLE
Created documentation for contributed dta/use-cases area

### DIFF
--- a/contributions/dta/use-cases/README.md
+++ b/contributions/dta/use-cases/README.md
@@ -1,0 +1,35 @@
+# Use Cases Contribution
+
+> Submitted By Kristina Podnar on 2025-04-15 12:13 am Coordinated Universal Time to OASIS.
+> Reference OASIS document ID: 72730
+> Closed source OASIS download link for latest revision 1/1: [Download Latest Revision](https://groups.oasis-open.org/higherlogic/ws/groups/2c60b2cf-45d3-48cd-8594-0194f182b33d/download/72730/latest)
+> Metadata header: Data Provenance Standards V1	- Adoption Kit: Use Cases
+
+## Use Cases Provided
+
+The document provides four use cases:
+
+1. USE CASE 1 - Healthcare Insurance Data Procurement
+2. USE CASE 2 - Media Consumption Pattern Dataset for Consumer Behavior Insights
+3. USE CASE 3 - Financial Services Customer Product Enablement
+4. USE CASE 4 - Enhancing Global Logistics Efficiency Through AI-driven Tariff Harmonization
+
+Every use case is presented using the following structure:
+
+- Persona
+  - Role
+  - Background 
+  - Responsibilities
+- Use Case
+  - Goals
+  - Challenges
+- How the Standards are Used
+- Outcome
+ 
+## Files
+
+The originally provided file in format OfficeXML (DOCX) is provided as provenance support.
+
+The content has been transcribed to markdown text format by Stefan Hagen <stefan@hagen.link>.
+
+Period of transcription: 2025-07-20 - current.


### PR DESCRIPTION
To support the other co-editors, this change-set documents the Data and Trust Alliance Use Case document contribution.

In addition it transcribes the content into the markdown text format to allow more easily the practical inclusion of the contributed content into an OASIS work product (a.k.a. the use-cases spec).