### PR TITLE
TC Meeting Minutes – July 29, 2025

### DIFF
--- a/MeetingMinutes/2025-07-29-meeting.md
+++ b/MeetingMinutes/2025-07-29-meeting.md
@@ -1,0 +1,101 @@
+# OASIS TC Meeting – July 29, 2025
+
+**Date:** July 29, 2025  
+**Time:** 7:00 AM PDT / 10:00 AM EDT / 14:00 UTC / 16:00 CET  
+
+**Chairs:**  
+- Bryan Bortnick (IBM)  
+- Lisa Bobbitt (Cisco)  
+- Fotis Psallidas (Microsoft)  
+
+**Secretary:**  
+- Kristina Podnar (Data & Trust Alliance)  
+
+**Meeting Recording:**  
+[Watch Recording on Zoom](https://thecge-net.zoom.us/rec/share/j9kh7DCrrZ74OlCUTLJLZY0whb2OdmycTFevMbaWfByF1XXRBOyuykJSlaBk_X1X.1Q8YoD6uX9vmNFOz)  
+**Passcode:** `+xUYit04`  
+
+**Presentation Slides:**  
+[View Presentation](https://docs.google.com/presentation/d/1wfJOtRwoOEhI9vfbPp0O6yzaFXEMG5gCz8PwYaNr5SY/edit?slide=id.gc6f9544c1_0_0#slide=id.gc6f9544c1_0_0)
+
+---
+
+## Attendance
+
+| First Name | Last Name  | Affiliation              | Roles                    | Present |
+|:-----------|:-----------|:-------------------------|:-------------------------|:--------|
+| Lisa       | Bobbitt    | Cisco                    | Voting Member, Co-Chair  | Yes     |
+| Bryan      | Bortnick   | IBM                      | Voting Member, Co-Chair  | Yes     |
+| Fotis      | Psallidas  | Microsoft                | Voting Member, Co-Chair  | Yes     |
+| Carlyn     | Connolly   | Data & Trust Alliance    | Voting Member            | Yes     |
+| Kate       | Gallo      | Blue Street Data         | Voting Member            | Yes     |
+| Stefan     | Hagen      | Individual               | Voting Member            | Yes     |
+| David      | Kemp       | National Security Agency | Voting Member            | Yes     |
+| Wyatt      | Schroth    | Blue Street Data         | Voting Member            | Yes     |
+| Kelsey     | Schulte    | Intel                    | Voting Member            | Yes     |
+| Jautau     | White      | Microsoft                | Voting Member            | Yes     |
+| Roman      | Zhukov     | Red Hat                  | *Non-Voting* (missed 2)  | Yes     |
+| Cheryl     | Radix      | Cisco                    | Guest                    | Yes     |
+| Kelly      | Cullinane  | OASIS Staff              | Staff                    | Yes     |
+
+> **Note:**  
+> - **Andy Hannah** and **Roman Zhukov** missed both the July 15 and July 29 meetings and have lost voting rights per OASIS rules.
+
+---
+
+## Agenda
+
+1. Welcome  
+2. Draft Executive Summary and Use Cases  
+3. Action Items and Next Steps for Refining Content  
+4. Close Out  
+
+---
+
+## Discussion Summary
+
+### 1. **Welcome**
+- Bryan Bortnick called the meeting to order.  
+- Kelly Cullinane confirmed that quorum was met.  
+- Cheryl Radix (Cisco) was welcomed as a new participant supporting schema development work.
+
+### 2. **Draft Executive Summary and Use Cases**
+- **Executive Summary:**  
+  - The draft [Executive Brief](https://docs.google.com/document/d/1Xn8Fo1lgZFU5aKnS0x95enqhH-otd3os2ojtEDD_yCA/edit?usp=sharing) is open for final review.  
+  - Members are encouraged to provide final comments before the next meeting.  
+- **Use Cases Committee Note:**  
+  - Lisa previewed the current draft of the [Use Cases Document](https://github.com/oasis-tcs/dps/blob/main/work-products/use-cases/prov-use-v0.1-cn01.md).  
+  - Numbered sections and metadata links have been added for clarity.  
+  - A motion was made, seconded, and approved to formally add Stefan Hagen as co-editor.  
+  - Members should reference section numbers when providing feedback to streamline review.
+
+### 3. **Action Items and Next Steps for Refining Content**
+- Final versions of the Executive Brief and Use Cases are targeted for end of August, with September as a contingency.
+- Lisa and Stefan will align the use cases with updated schema structure.
+- David Kemp and Stefan Hagen are finalizing top-level metadata fields for consistency.
+- The group unanimously adopted a naming convention:
+  - **Type names:** Capitalized (e.g., `DataItem`)
+  - **Variable names:** kebab-case (e.g., `data-item`)
+
+### 4. **Close Out**
+- Bryan reminded the group to review the Executive Brief and Use Cases before the next meeting.  
+- The next TC meeting is scheduled for **August 12, 2025 at 10:00 AM EDT**.
+
+---
+
+## Actions and Next Steps
+
+| Action Item | Owner(s) | Due Date |
+|-------------|----------|----------|
+| Final comments on [Executive Brief](https://docs.google.com/document/d/1Xn8Fo1lgZFU5aKnS0x95enqhH-otd3os2ojtEDD_yCA/edit?usp=sharing) | All TC members | Aug 12, 2025 |
+| Feedback on [Use Cases Document](https://github.com/oasis-tcs/dps/blob/main/work-products/use-cases/prov-use-v0.1-cn01.md) | All TC members | Aug 12, 2025 |
+| Finalize top-level metadata attributes | David Kemp, Stefan Hagen | Aug 31, 2025 |
+| Incorporate edits and finalize Use Cases v1 | Lisa Bobbitt, Stefan Hagen | Aug 31, 2025 |
+| Share final logo and social media plan | Chairs + Jane | August 2025 |
+
+---
+
+## Next Meeting
+
+**Date:** August 12, 2025  
+**Time:** 10:00 AM EDT


### PR DESCRIPTION
This document captures the official meeting minutes of the OASIS Data Provenance Standards Technical Committee held on July 29, 2025. It includes a record of attendance, agenda items, discussion highlights, decisions made (including naming conventions and editor roles), shared resources (slides and documents), and key action items for the upcoming weeks. The minutes serve as a reference point for TC members and stakeholders as the committee prepares to finalize and publish the Executive Brief and Use Cases v1.