### PR TITLE
Add August 12, 2025 DPS TC Meeting Minutes

### DIFF
--- a/MeetingMinutes/2025-08-12-meeting.md
+++ b/MeetingMinutes/2025-08-12-meeting.md
@@ -21,19 +21,19 @@
 
 ## Attendance
 
-| First Name | Last Name  | Affiliation               | Roles                    | Present |
-|:-----------|:-----------|:--------------------------|:-------------------------|:--------|
-| Lisa       | Bobbitt    | Cisco Systems             | Voting Member, Co-Chair  | Yes     |
-| Bryan      | Bortnick   | IBM                       | Voting Member, Co-Chair  | Yes     |
-| Carlyn     | Connolly   | Data & Trust Alliance     | Voting Member            | Yes     |
-| Kate       | Gallo      | Blue Street Data          | Voting Member            | Yes     |
-| Stefan     | Hagen      | Individual                | Voting Member            | Yes     |
-| Andy       | Hannah     |                           | Voting Member            | Yes     |
-| David      | Kemp       | National Security Agency  | Voting Member            | Yes     |
-| Kristina   | Podnar     | Data & Trust Alliance     | Voting Member, Secretary | Yes     |
-| Wyatt      | Schroth    | Blue Street Data          | Voting Member            | Yes     |
-| Kelsey     | Schulte    | Intel Corporation         | Voting Member            | Yes     |
-| Jane       | Harnad     | OASIS                     | OASIS Staff Contact      | Yes     |
+| First Name | Last Name | Affiliation              | Roles                    | Present |
+|:-----------|:----------|:-------------------------|:-------------------------|:--------|
+| Lisa       | Bobbitt   | Cisco Systems            | Voting Member, Co-Chair  | Yes     |
+| Bryan      | Bortnick  | IBM                      | Voting Member, Co-Chair  | Yes     |
+| Carlyn     | Connolly  | Data & Trust Alliance    | Voting Member            | Yes     |
+| Kate       | Gallo     | Blue Street Data         | Voting Member            | Yes     |
+| Stefan     | Hagen     | Individual               | Voting Member            | Yes     |
+| Andy       | Hannah    | Blue Street Data         | Voting Member            | Yes     |
+| David      | Kemp      | National Security Agency | Voting Member            | Yes     |
+| Kristina   | Podnar    | Data & Trust Alliance    | Voting Member, Secretary | Yes     |
+| Wyatt      | Schroth   | Blue Street Data         | Voting Member            | Yes     |
+| Kelsey     | Schulte   | Intel Corporation        | Voting Member            | Yes     |
+| Jane       | Harnad    | OASIS                    | OASIS Staff Contact      | Yes     |
 
 **Lost voting rights (missed 2 consecutive meetings):**  
 - Saira Jesani  
@@ -54,6 +54,7 @@
 2. Call for new TC secretary (replacing Kristina)
 3. Updates on workstreams
 4. Social media plan progress and opportunities for sharing
+
 5. Next steps
 
 ---
@@ -108,15 +109,16 @@
 
 ## Actions and next steps
 
-| Action Item | Owner(s) | Due Date |
-|-------------|----------|----------|
-| Provide feedback on schema “worldwide” handling and empty/inclusion/exclusion semantics | All TC members | Aug 26, 2025 |
-| Add simple and step-through examples to use case collection | Lisa Bobbitt, Stefan Hagen | Aug 26, 2025 |
-| Submit any additional edits for Use Cases document | All TC members | Aug 19, 2025 |
-| Complete Executive Brief slide deck for review | Jane Harnad | Aug 26, 2025 |
-| Volunteer or nominate candidate for TC secretary role | All TC members | Aug 26, 2025 |
-| Confirm RSA CFP submission team | Jane Harnad + volunteers | Aug 18, 2025 |
-| Share social media content calendar with TC | Jane Harnad | Aug 13, 2025 |
+| Action Item                                                                             | Owner(s)                   | Due Date     |
+|:----------------------------------------------------------------------------------------|:---------------------------|:-------------|
+| Provide feedback on schema “worldwide” handling and empty/inclusion/exclusion semantics | All TC members             | Aug 26, 2025 |
+| Add simple and step-through examples to use case collection                             | Lisa Bobbitt, Stefan Hagen | Aug 26, 2025 |
+| Provide example for OASIS Technical Report                                              | Stefan Hagen               | Aug 26, 2025 |
+| Submit any additional edits for Use Cases document                                      | All TC members             | Aug 19, 2025 |
+| Complete Executive Brief slide deck for review                                          | Jane Harnad                | Aug 26, 2025 |
+| Volunteer or nominate candidate for TC secretary role                                   | All TC members             | Aug 26, 2025 |
+| Confirm RSA CFP submission team                                                         | Jane Harnad + volunteers   | Aug 18, 2025 |
+| Share social media content calendar with TC                                             | Jane Harnad                | Aug 13, 2025 |
 
 ---
 

--- a/MeetingMinutes/2025-08-12-meeting.md
+++ b/MeetingMinutes/2025-08-12-meeting.md
@@ -1,0 +1,126 @@
+# OASIS TC Meeting – August 12, 2025
+
+**Date:** August 12, 2025  
+**Time:** 10:00 AM EDT  
+
+**Chairs:**  
+- Bryan Bortnick (IBM)  
+- Lisa Bobbitt (Cisco)  
+
+**Secretary:**  
+- Kristina Podnar (Data & Trust Alliance)  
+
+**Meeting recording:**  
+[Watch Recording on Zoom](https://thecge-net.zoom.us/rec/share/r-1qKiCGdWmepbxrHz2agJwl5GqfCgiRw5e0oIGdKIvF1NJIHS3I_nUFX-O4zR1f.v8JbZbc8Xn0Rbopa)  
+**Passcode:** `!nr5X$$p`  
+
+**Presentation slides:**  
+[View Presentation](https://docs.google.com/presentation/d/1W9_tibcWw1RUcBpQ_dem9BDs5AZ_0aAm9HXM-D_-xlQ/edit?slide=id.gc6f9544c1_0_0#slide=id.gc6f9544c1_0_0)
+
+---
+
+## Attendance
+
+| First Name | Last Name  | Affiliation               | Roles                    | Present |
+|:-----------|:-----------|:--------------------------|:-------------------------|:--------|
+| Lisa       | Bobbitt    | Cisco Systems             | Voting Member, Co-Chair  | Yes     |
+| Bryan      | Bortnick   | IBM                       | Voting Member, Co-Chair  | Yes     |
+| Carlyn     | Connolly   | Data & Trust Alliance     | Voting Member            | Yes     |
+| Kate       | Gallo      | Blue Street Data          | Voting Member            | Yes     |
+| Stefan     | Hagen      | Individual                | Voting Member            | Yes     |
+| Andy       | Hannah     |                           | Voting Member            | Yes     |
+| David      | Kemp       | National Security Agency  | Voting Member            | Yes     |
+| Kristina   | Podnar     | Data & Trust Alliance     | Voting Member, Secretary | Yes     |
+| Wyatt      | Schroth    | Blue Street Data          | Voting Member            | Yes     |
+| Kelsey     | Schulte    | Intel Corporation         | Voting Member            | Yes     |
+| Jane       | Harnad     | OASIS                     | OASIS Staff Contact      | Yes     |
+
+**Lost voting rights (missed 2 consecutive meetings):**  
+- Saira Jesani  
+- Bryan Kyle  
+- Greg Ott  
+- John Sabo  
+
+**At risk of losing voting rights (if next meeting missed):**  
+- Fotis Psallidas  
+- Jautau White  
+- Roman Zhukov  
+
+---
+
+## Agenda
+
+1. Welcome
+2. Call for new TC secretary (replacing Kristina)
+3. Updates on workstreams
+4. Social media plan progress and opportunities for sharing
+5. Next steps
+
+---
+
+## Discussion Summary
+
+### 1. **Welcome**
+- Bryan opened the meeting and confirmed quorum.  
+- Reminder that today’s agenda includes specification alignment, content refinement, and outreach planning.
+
+### 2. **Specification discussion**
+- Kristina summarized the D&TA working group’s approach:
+  - Defaults to “worldwide” with possible country-specific exclusions.
+  - Uses inclusion/exclusion lists rather than requiring exhaustive country-by-country coding.
+  - Avoids prescriptive compliance labels; instead provides factual metadata so implementers can decide compliance.
+- Stefan raised concerns about ambiguity when fields are empty vs. explicitly set; suggested defining semantics for “empty,” “allow,” and “deny.”
+- David proposed introducing priority layers for allow/deny logic to resolve conflicts (e.g., allow worldwide, exclude Italy).
+- Group agreed on:
+  - Need for explicit definitions and examples.
+  - Possible creation of a simple “examples” directory showing schema instances.
+  - Future consideration of controlled vocabularies and value catalogs.
+
+### 3. **Use cases document updates**
+- Lisa and Stefan continuing edits; next release targeted for next week.
+- Members encouraged to submit final feedback this week.
+- Agreement to align examples with updated schema definitions.
+- Consider adding:
+  - Simplistic “worldwide except…” examples.
+  - Step-through persona-based scenarios showing metadata creation and application.
+
+### 4. **Executive brief updates**
+- Most comments resolved; one outstanding item on adding a high-level executive checklist or summary call-out.
+- Jane will reformat into a slide deck for visual presentation; target completion before next meeting.
+- Stefan suggested exploring an OASIS Technical Report format for broader conference and outreach use.
+
+### 5. **Secretary role transition**
+- Kristina announced she will roll off from D&TA at end of August; new TC secretary needed.
+- Call for volunteers; role described as manageable and a good vantage point for committee work.
+- If no volunteer by next meeting, co-chairs may temporarily assume responsibilities.
+
+### 6. **Social Media and Outreach Plan**
+- Jane presented an ambitious draft plan:
+  - Content calendar through December.
+  - Cross-promotion with other OASIS TCs.
+  - Tracking performance metrics for posts.
+  - Outreach to external blogs, conferences, and media (e.g., RSA blog post and CFP submission by Aug 18).
+  - Member and partner logo usage guidelines.
+- Request for TC volunteers and possible marketing contacts from member organizations to assist.
+- Discussion on involving D&TA companies and other implementers in amplification efforts.
+
+---
+
+## Actions and next steps
+
+| Action Item | Owner(s) | Due Date |
+|-------------|----------|----------|
+| Provide feedback on schema “worldwide” handling and empty/inclusion/exclusion semantics | All TC members | Aug 26, 2025 |
+| Add simple and step-through examples to use case collection | Lisa Bobbitt, Stefan Hagen | Aug 26, 2025 |
+| Submit any additional edits for Use Cases document | All TC members | Aug 19, 2025 |
+| Complete Executive Brief slide deck for review | Jane Harnad | Aug 26, 2025 |
+| Volunteer or nominate candidate for TC secretary role | All TC members | Aug 26, 2025 |
+| Confirm RSA CFP submission team | Jane Harnad + volunteers | Aug 18, 2025 |
+| Share social media content calendar with TC | Jane Harnad | Aug 13, 2025 |
+
+---
+
+## Next meeting
+
+**Date:** August 26, 2025  
+**Time:** 10:00 AM EDT  


### PR DESCRIPTION
This commit adds the official meeting minutes for the August 12, 2025 Data Provenance Standards (DPS) Technical Committee meeting. The file includes:
- Attendance list with voting status updates
- Discussion summary covering specification updates, “worldwide” metadata handling, use cases, executive brief, secretary transition, and outreach planning
- Agreed action items and deadlines
- Links to meeting recording and presentation slides