### PR TITLE
Add meeting minutes for OASIS DPS TC – August 26, 2025

### DIFF
--- a/MeetingMinutes/2025-08-26-meeting.md
+++ b/MeetingMinutes/2025-08-26-meeting.md
@@ -1,0 +1,107 @@
+# OASIS DPS TC Meeting – August 26, 2025
+
+**Date:** August 26, 2025  
+**Time:** 10:00 AM EDT  
+
+**Chairs:**  
+- Bryan Bortnick (IBM)  
+- Lisa Bobbitt (Cisco)  
+- Fotis Psallidas (Microsoft)  
+
+**Secretary:**  
+- Kristina Podnar (Data & Trust Alliance)  
+*Note: Kristina is departing the role; going forward, the secretary responsibilities will be covered jointly by the co-chairs until a replacement is appointed.*
+
+**Meeting recording:**  
+[Watch Recording on Zoom](https://thecge-net.zoom.us/rec/share/ewoFXPEtzWkQx_1-hPlucQhxlGOSD9znl5uudo29k1bY9cjvH0WYXautGRYJDfHU.Ou_tO_RBdhU5WWJc)  
+**Passcode:** `J13Z#9Hx`  
+
+**Presentation slides:**  
+[View Presentation](https://drive.google.com/file/d/1HrS2pjb8zXd3OljpjGHM858Ek7iM4h7e/view?usp=sharing)
+
+---
+
+## Attendance
+
+| First Name | Last Name | Affiliation              | Roles                           | Present |
+|:-----------|:----------|:-------------------------|:--------------------------------|:--------|
+| Lisa       | Bobbitt   | Cisco Systems            | Voting Member, Co-Chair         | Yes     |
+| Bryan      | Bortnick  | IBM                      | Voting Member, Co-Chair         | Yes     |
+| Fotis      | Psallidas | Microsoft                | Voting Member, Co-Chair         | Yes     |
+| Mic        | Bowman    | Intel Corporation        | Member                          | Yes     |
+| Carlyn     | Connolly  | Data & Trust Alliance    | Voting Member                   | Yes     |
+| Kate       | Gallo     | Blue Street Data         | Voting Member                   | Yes     |
+| Stefan     | Hagen     | Individual               | Voting Member                   | Yes     |
+| Andy       | Hannah    | Blue Street Data         | Voting Member                   | Yes     |
+| David      | Kemp      | National Security Agency | Voting Member                   | Yes     |
+| Kristina   | Podnar    | Data & Trust Alliance    | Voting Member, Secretary        | Yes     |
+| Wyatt      | Schroth   | Blue Street Data         | Voting Member                   | Yes     |
+| Kelsey     | Schulte   | Intel Corporation        | Voting Member                   | Yes     |
+| Jautau     | White     | Microsoft                | Voting Member                   | Yes     |
+| Roman      | Zhukov    | Red Hat                  | Voting Member                   | Yes     |
+| Cheryl     | Radix     | Cisco Systems            | Member                          | Yes     |
+| Kelly      | Cullinane | OASIS                    | OASIS Staff                     | Yes     |
+| Jane       | Harnad    | OASIS                    | OASIS Staff                     | Yes     |
+
+---
+
+## Agenda
+
+1. Welcome  
+2. Standards for Public Comment Release  
+   - Review current draft status  
+   - Decisions & outstanding needs  
+3. Subcommittee Work Products Progression  
+4. Engagement & Outreach  
+5. TC Secretary Role & Next Steps  
+
+---
+
+## Discussion Summary
+
+### 1. Welcome
+- Bryan confirmed quorum and opened the meeting.  
+- Agenda focused on standards readiness, outreach, and TC administration.
+
+### 2. Standards for Public Comment Release
+- Lisa and Stefan presented schema updates to support both customer and personal data.  
+- Members asked to review draft schema and provide feedback before broader review.  
+- **Agreement:** Two-week internal review period before release; target publication in September.
+
+### 3. Subcommittee Work Products Progression
+- Jane shared draft executive brief (PDF and slide deck).  
+- Both drafts are visually engaging and nearly complete.  
+- Company logos to be added after member confirmation.  
+- Use cases are being refined, pending alignment with schema changes.  
+- Stefan suggested developing an OASIS Technical Report as a bridge between executive brief and technical specification; committee agreed, Stefan to lead with Lisa’s support.
+
+### 4. Engagement & Outreach
+- Committee emphasized importance of real-world data examples to validate metadata schema.  
+- Kristina will check if sanitized/anonymized datasets can be provided from D&TA.  
+- David recommended a “hello world” style example for clarity.  
+- Fotis shared plans to present TC work at an AI governance panel in London. Draft documents and links will be used to encourage awareness and adoption.
+
+### 5. TC Secretary Role & Next Steps
+- Kristina reiterated her departure from the secretary role.  
+- No volunteers yet; interim coverage will be shared by co-chairs (Lisa, Bryan, Fotis).  
+
+---
+
+## Actions and Next Steps
+
+| Action Item                                                   | Owner(s)                    | Due Date     |
+|:--------------------------------------------------------------|:----------------------------|:-------------|
+| Review and provide comments on executive brief PDF and slides | All TC members              | Sep 9, 2025  |
+| Finalize schema changes and align use cases                   | Lisa Bobbitt, Stefan Hagen  | Sep 9, 2025  |
+| Draft Technical Report / White Paper outline                  | Stefan Hagen, Lisa Bobbitt  | Sep 9, 2025  |
+| Collect sample datasets / sanitized examples for validation   | Kristina Podnar, David Kemp | Sep 9, 2025  |
+| Update draft Data Provenance Metadata spec v1.0               | David Kemp, Stefan Hagen    | Sep 9, 2025  |
+| Identify interim secretary process and revisit recruitment    | Chairs                      | Sep 9, 2025  |
+| Gather/share draft materials for London AI governance panel   | Fotis Psallidas, Chairs     | Before Sep 2 |
+
+---
+
+## Next Meeting
+
+**Date:** September 9, 2025  
+**Time:** 10:00 AM EDT

--- a/MeetingMinutes/2025-08-26-meeting.md
+++ b/MeetingMinutes/2025-08-26-meeting.md
@@ -23,25 +23,25 @@
 
 ## Attendance
 
-| First Name | Last Name | Affiliation              | Roles                           | Present |
-|:-----------|:----------|:-------------------------|:--------------------------------|:--------|
-| Lisa       | Bobbitt   | Cisco Systems            | Voting Member, Co-Chair         | Yes     |
-| Bryan      | Bortnick  | IBM                      | Voting Member, Co-Chair         | Yes     |
-| Fotis      | Psallidas | Microsoft                | Voting Member, Co-Chair         | Yes     |
-| Mic        | Bowman    | Intel Corporation        | Member                          | Yes     |
-| Carlyn     | Connolly  | Data & Trust Alliance    | Voting Member                   | Yes     |
-| Kate       | Gallo     | Blue Street Data         | Voting Member                   | Yes     |
-| Stefan     | Hagen     | Individual               | Voting Member                   | Yes     |
-| Andy       | Hannah    | Blue Street Data         | Voting Member                   | Yes     |
-| David      | Kemp      | National Security Agency | Voting Member                   | Yes     |
-| Kristina   | Podnar    | Data & Trust Alliance    | Voting Member, Secretary        | Yes     |
-| Wyatt      | Schroth   | Blue Street Data         | Voting Member                   | Yes     |
-| Kelsey     | Schulte   | Intel Corporation        | Voting Member                   | Yes     |
-| Jautau     | White     | Microsoft                | Voting Member                   | Yes     |
-| Roman      | Zhukov    | Red Hat                  | Voting Member                   | Yes     |
-| Cheryl     | Radix     | Cisco Systems            | Member                          | Yes     |
-| Kelly      | Cullinane | OASIS                    | OASIS Staff                     | Yes     |
-| Jane       | Harnad    | OASIS                    | OASIS Staff                     | Yes     |
+| First Name | Last Name | Affiliation                  | Roles                           | Present |
+|:-----------|:----------|:-----------------------------|:--------------------------------|:--------|
+| Lisa       | Bobbitt   | Cisco Systems                | Voting Member, Co-Chair         | Yes     |
+| Bryan      | Bortnick  | IBM                          | Voting Member, Co-Chair         | Yes     |
+| Fotis      | Psallidas | Microsoft                    | Voting Member, Co-Chair         | Yes     |
+| Mic        | Bowman    | Intel Corporation            | Member                          | Yes     |
+| Carlyn     | Connolly  | Data &map; Trust Alliance    | Voting Member                   | Yes     |
+| Kate       | Gallo     | Blue Street Data             | Voting Member                   | Yes     |
+| Stefan     | Hagen     | Individual                   | Voting Member                   | Yes     |
+| Andy       | Hannah    | Blue Street Data             | Voting Member                   | Yes     |
+| David      | Kemp      | National Security Agency     | Voting Member                   | Yes     |
+| Kristina   | Podnar    | Data &amp; Trust Alliance    | Voting Member, Secretary        | Yes     |
+| Wyatt      | Schroth   | Blue Street Data             | Voting Member                   | Yes     |
+| Kelsey     | Schulte   | Intel Corporation            | Voting Member                   | Yes     |
+| Jautau     | White     | Microsoft                    | Voting Member                   | Yes     |
+| Roman      | Zhukov    | Red Hat                      | Voting Member                   | Yes     |
+| Cheryl     | Radix     | Cisco Systems                | Member                          | Yes     |
+| Kelly      | Cullinane | OASIS                        | OASIS Staff                     | Yes     |
+| Jane       | Harnad    | OASIS                        | OASIS Staff                     | Yes     |
 
 ---
 
@@ -60,28 +60,33 @@
 ## Discussion Summary
 
 ### 1. Welcome
+
 - Bryan confirmed quorum and opened the meeting.  
 - Agenda focused on standards readiness, outreach, and TC administration.
 
 ### 2. Standards for Public Comment Release
+
 - Lisa and Stefan presented schema updates to support both customer and personal data.  
 - Members asked to review draft schema and provide feedback before broader review.  
 - **Agreement:** Two-week internal review period before release; target publication in September.
 
 ### 3. Subcommittee Work Products Progression
+
 - Jane shared draft executive brief (PDF and slide deck).  
 - Both drafts are visually engaging and nearly complete.  
 - Company logos to be added after member confirmation.  
 - Use cases are being refined, pending alignment with schema changes.  
 - Stefan suggested developing an OASIS Technical Report as a bridge between executive brief and technical specification; committee agreed, Stefan to lead with Lisa’s support.
 
-### 4. Engagement & Outreach
+### 4. Engagement and Outreach
+
 - Committee emphasized importance of real-world data examples to validate metadata schema.  
 - Kristina will check if sanitized/anonymized datasets can be provided from D&TA.  
 - David recommended a “hello world” style example for clarity.  
 - Fotis shared plans to present TC work at an AI governance panel in London. Draft documents and links will be used to encourage awareness and adoption.
 
-### 5. TC Secretary Role & Next Steps
+### 5. TC Secretary Role and Next Steps
+
 - Kristina reiterated her departure from the secretary role.  
 - No volunteers yet; interim coverage will be shared by co-chairs (Lisa, Bryan, Fotis).  
 


### PR DESCRIPTION
This PR introduces the official meeting minutes for the OASIS DPS Technical Committee held on August 26, 2025.  

The minutes document the committee’s progress toward releasing the draft standard for public comment, updates on subcommittee deliverables, outreach and engagement planning, and administrative transitions within the TC. Action items and due dates are captured to guide member contributions ahead of the next meeting.