### PR TITLE
Meeting minutes for OASIS DPS TC – 2025-09-09

### DIFF
--- a/MeetingMinutes/2025-09-09-meeting.md
+++ b/MeetingMinutes/2025-09-09-meeting.md
@@ -1,0 +1,100 @@
+# OASIS TC Meeting – Sep 9, 2025
+
+**Date:** Sep 9, 2025  
+**Time:** 7:00 AM PDT / 10:00 AM EDT / 14:00 UTC / 16:00 CET  
+
+**Chairs:**  
+- Bryan Bortnick (IBM)  
+- Lisa Bobbitt (Cisco)  
+- Fotis Psallidas (Microsoft)  
+
+**Secretary:**  
+- Fotis Psallidas (acting on behalf of the co-chairs until a secretary is appointed).
+
+**Meeting Recording:**  [Watch Recording on Zoom](https://thecge-net.zoom.us/rec/share/2bCrOmUO4hz87kujTpKeOmzFgpnIjFp3CCDgS2OuniBXxKV4oJcC2MDvsEA89ett.BJtrn4qHT43QQEBb)  
+**Passcode:** `J^jb7Tng`  
+---
+
+
+## Attendance
+
+| First Name | Last Name  | Affiliation               | Roles                    | Present |
+|:-----------|:-----------|:--------------------------|:-------------------------|:--------|
+| Bryan      | Bortnick   | IBM                       | Voting Member, Co-Chair  | Yes     |
+| Fotis      | Psallidas  | Microsoft Corporation     | Voting Member, Co-Chair  | Yes     |
+| Carlyn     | Connolly   | Data &amp; Trust Alliance | Voting Member            | Yes     |
+| Kelsey     | Schulte    | Intel Corporation         | Voting Member            | Yes     |
+| Stefan     | Hagen      | Individual                | Voting Member            | Yes     |
+| Cheryl     | Radix      | Cisco Systems             | Voting Member            | Yes     |
+| Roman      | Zhukov     | Red Hat                   | Voting Member            | Yes     |
+| Kelly      | Cullinane  | OASIS                     | OASIS Staff Contact      | Yes     |
+| Bryan      | Kyle       | IBM                       | Voting Member            | Yes     |
+| Peter      | Stockburger | Dentons                 | Member (first meeting)   | Yes     |
+
+## Agenda
+
+1. Welcome  
+2. Dentons introduction
+3. Call for new TC Secretary
+4. Updates on workstreams
+    1. Executive brief (updated versions)
+    2. Use cases
+    3. Metadata definitions
+    4. Social media plan progress and opportunities for sharing
+
+## Discussion Summary
+
+### 1. Welcome
+- Bryan Bortnick called the meeting to order.
+- Quorum was confirmed by Kelly Cullinane.
+
+### 2. Dentons introduction
+- Bryan Bortnick and Kelly Cullinane announced Dentons participation in the TC.
+- Peter Stockburger (Dentons) was welcomed.
+- Peter Stockburger discussed challenges around data readiness and mobility, and how Dentons work aligns with the TC's goals.
+
+### 3. Call for new TC Secretary
+- Bryan Bortnick called for interest in the TC secretary role. No interest was expressed during the meeting. Members may express interest or nominate a secretary before the next TC meeting.
+
+### 4. Updates on workstreams
+
+#### 4.1. Executive brief (updated versions)
+
+- Bryan Bortnick reviewed the documents and provided the latest updates and outline.
+- A final version of the slides and the PDF will be made available soon.
+- Members were asked to review the materials and provide comments.
+
+#### 4.2. Use cases
+
+- The review process is slightly delayed; Lisa Bobbitt will update the TC soon.
+
+#### 4.3. Metadata definitions
+
+- Stefan Hagen reviewed the submitted PRs:
+    1. PR#83: [Initial draft for the technical report](https://github.com/oasis-tcs/dps/pull/83)
+    2. PR#84: [Use Cases Document - Editor revision 2025-09-09](https://github.com/oasis-tcs/dps/pull/84)
+    3. PR#85: [Data Provenance Metadata Document - Editor revision 2025-09-09](https://github.com/oasis-tcs/dps/pull/85)
+- Call for everyone to review and comment on the open PRs.
+
+#### 4.4. Social media plan progress and opportunities for sharing
+
+- No updates.
+
+--- 
+
+## Action Items
+
+| Action Item | Owner(s) | Due Date |
+|-------------|----------|----------|
+| Final comments on Executive Brief [PDF](https://drive.google.com/file/d/1B7MibP-lSxMUjZaq7zKPTNxBeeeRQVlk/view) and [Slides](https://drive.google.com/file/d/1duUqeP3dOyDtUu2ZOmabDgHUQZH1QkqZ/view)| All TC members | Sep 23, 2025 |
+| Review [PR#83 - Draft on Technical Report](https://github.com/oasis-tcs/dps/pull/83) | All TC members | Sep 23, 2025 |
+| Review [PR#84 - Use Cases Document - Editor Revision PR#84](https://github.com/oasis-tcs/dps/pull/84) | All TC members | Sep 23, 2025 |
+| Review [PR#85 - Data Provenance Metadata Document - Editor revision 2025-09-09](https://github.com/oasis-tcs/dps/pull/85) | All TC members | Sep 23, 2025 |
+| Volunteer or nominate candidate for TC secretary role                                   | All TC members             | Sep 23, 2025 |
+
+---
+
+## Next Meeting
+
+**Date:** Sep 23, 2025  
+**Time:** 7:00 AM PDT / 10:00 AM EDT / 14:00 UTC / 16:00 CET


### PR DESCRIPTION
This PR introduces the official meeting minutes for the OASIS DPS Technical Committee held on September 9, 2025.