### PR TITLE
Fixed links to RFC references (implements #156)

### DIFF
--- a/work-products/metadata-spec/prov.md
+++ b/work-products/metadata-spec/prov.md
@@ -196,7 +196,7 @@ PET
 ## 3.1 Key Words
 
 The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**NOT RECOMMENDED**", "**MAY**",
-and "**OPTIONAL**" in this document are to be interpreted as described in BCP 14 \[RFC2119\] \[RFC8174\] when, and only when, they appear in all capitals, as shown here.
+and "**OPTIONAL**" in this document are to be interpreted as described in BCP 14 \[[RFC2119](#normative-references)\] and \[[RFC8174](#normative-references)\] when, and only when, they appear in all capitals, as shown here.
 
 ## 3.2 Typographical Conventions
 


### PR DESCRIPTION
Note: 
>We should switch to a clean source approach like I implemented for (CSAF, MQTT, OpenEoX, and SARIF) to derive semantic references, automatic section, figure, and table numbering from clean sources.

This implementation only documents how it could look using the publication approach in use for CSDPR01. In the suggested clean and semantic source representation such links would be written as:
```[cite](#RFC2119) and [cite](#RFC8174)```
instead of:
```\[[RFC2119](#normative-references)\] and \[[RFC8174](#normative-references)\]```
