### PR TITLE
Add proof field to DataProvenance schema (implements #170)

### DIFF
--- a/prov-meta-1.0/prose/edit/src/schema-01-primary.md
+++ b/prov-meta-1.0/prose/edit/src/schema-01-primary.md
@@ -4,13 +4,13 @@ The root object of a Data Provenance Metadata record contains five required memb
 
 \columns=iiii,nnnnnnnnnn,tttttttttt,hhhh,ddddddddddddddddddddddddddddddddddddddd
 
-| ID | Name       | Type        | \# | Description                                                                                                                                             |
-|---:|:-----------|:------------|:---|:--------------------------------------------------------------------------------------------------------------------------------------------------------|
-|  1 | $schema    | String /uri | 1  | The URI identifying the schema this JSON object must be valid against. For this version the value is always the URI of the data-provenance JSON schema. |
-|  2 | set        | Set         | 1  | Set-level metadata about this provenance metadata record.                                                                                               |
-|  3 | source     | Source      | 1  | Characterizes the content and source of the dataset.                                                                                                    |
-|  4 | provenance | Provenance  | 1  | Describes the provenance of the dataset.                                                                                                                |
-|  5 | use        | Use         | 1  | Describes legal use and restrictions that apply to the dataset.                                                                                         |
-|  6 | proof      | Proof       | 0..1  | Reserved for an external integrity or signing envelope's proof material. Structure is opaque to this specification.                                  |
+| ID | Name       | Type        | \#    | Description                                                                                                                                             |
+|---:|:-----------|:------------|:------|:--------------------------------------------------------------------------------------------------------------------------------------------------------|
+|  1 | $schema    | String /uri | 1     | The URI identifying the schema this JSON object must be valid against. For this version the value is always the URI of the data-provenance JSON schema. |
+|  2 | set        | Set         | 1     | Set-level metadata about this provenance metadata record.                                                                                               |
+|  3 | source     | Source      | 1     | Characterizes the content and source of the dataset.                                                                                                    |
+|  4 | provenance | Provenance  | 1     | Describes the provenance of the dataset.                                                                                                                |
+|  5 | use        | Use         | 1     | Describes legal use and restrictions that apply to the dataset.                                                                                         |
+|  6 | proof      | Proof       | 0..1  | Reserved for an external integrity or signing envelope's proof material. The internal structure is opaque to this specification.                        |
 
 Table: Type `DataProvenance` (Record){#tab:data-provenance-record}

--- a/prov-meta-1.0/prose/edit/src/schema-01-primary.md
+++ b/prov-meta-1.0/prose/edit/src/schema-01-primary.md
@@ -11,5 +11,6 @@ The root object of a Data Provenance Metadata record contains five required memb
 |  3 | source     | Source      | 1  | Characterizes the content and source of the dataset.                                                                                                    |
 |  4 | provenance | Provenance  | 1  | Describes the provenance of the dataset.                                                                                                                |
 |  5 | use        | Use         | 1  | Describes legal use and restrictions that apply to the dataset.                                                                                         |
+|  6 | proof      | Proof       | 0..1  | Reserved for an external integrity or signing envelope's proof material. Structure is opaque to this specification.                                  |
 
 Table: Type `DataProvenance` (Record){#tab:data-provenance-record}


### PR DESCRIPTION
A Data Provenance Metadata document MAY be carried as the payload of an external signing or integrity envelope (for example, a JOSE/JWS structure, a COSE structure, or a W3C Verifiable Credential). Where such an envelope is used, the document SHOULD be canonicalized per [RFC 8785 (JCS)](#RFC8785) prior to signing, consistent with the canonicalization approach already used in this specification's own publication tooling.

The optional `proof` member is reserved for this purpose. Its contents are intentionally left opaque to this specification — implementations that attach proof material MUST do so without requiring changes to this schema.

Implements #170 